### PR TITLE
Change tf.random_normal to tf.random.normal

### DIFF
--- a/efficientnet/model.py
+++ b/efficientnet/model.py
@@ -64,7 +64,7 @@ class ConvKernalInitializer(Initializer):
         del partition_info
         kernel_height, kernel_width, _, out_filters = shape
         fan_out = int(kernel_height * kernel_width * out_filters)
-        return tf.random_normal(
+        return tf.random.normal(
             shape, mean=0.0, stddev=np.sqrt(2.0 / fan_out), dtype=dtype)
 
 class DenseKernalInitializer(Initializer):


### PR DESCRIPTION
Tensorflow 2.0 comes with new aliases for random_normal. Using tf.random.normal instead of tf.random_normal should execute successfully. See https://stackoverflow.com/questions/59953127/tensorflow-2-1-0-has-no-attribute-random-normal